### PR TITLE
Call Caching and Workspace name collisions

### DIFF
--- a/app/controllers/user_workspaces_controller.rb
+++ b/app/controllers/user_workspaces_controller.rb
@@ -172,9 +172,11 @@ class UserWorkspacesController < ApplicationController
     begin
       @benchmark_analysis = BenchmarkAnalysis.find_by(id: params[:benchmark_analysis_id], user_id: current_user.id)
       if @benchmark_analysis.present?
+        call_cache = params[:call_cache].to_i == 1
         submission = user_fire_cloud_client(current_user).create_workspace_submission(@user_workspace.namespace, @user_workspace.name,
                                                                                       @benchmark_analysis.configuration_namespace,
-                                                                                      @benchmark_analysis.configuration_name)
+                                                                                      @benchmark_analysis.configuration_name,
+                                                                                      nil, nil, call_cache)
         redirect_to user_workspace_path(project: @user_workspace.namespace, name: @user_workspace.name),
                     notice: "'#{@benchmark_analysis.full_name}' was successfully submitted (submission: #{submission['submissionId']})" and return
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,8 @@ class User < ApplicationRecord
   attr_encrypted :refresh_token, key: ENV['ENCRYPTION_KEY']
 
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :registerable, :rememberable, :trackable,
+  # :confirmable, :lockable, :timeoutable and :omniauthable, :registerable,
+  devise :rememberable, :trackable,
          :omniauthable, :omniauth_providers => [:google_oauth2]
 
   # Associations

--- a/app/models/user_workspace.rb
+++ b/app/models/user_workspace.rb
@@ -11,6 +11,7 @@ class UserWorkspace < ApplicationRecord
   validates_format_of :name, with: ALPHANUMERIC_EXTENDED, message: ALPHANUMERIC_EXTENDED_MESSAGE
   validates_uniqueness_of :name, scope: :project
   validates_presence_of :name, :user, :project, :reference_analysis
+  validate :check_analysis_namespace, on: :create
   validate :create_benchmark_workspace
 
   def full_name
@@ -41,7 +42,7 @@ class UserWorkspace < ApplicationRecord
 
   # generate a default name based off of reference analysis name on initialization
   def default_name
-    self.reference_analysis.extract_wdl_keys(:analysis_wdl).join('-')
+    self.reference_analysis.extract_wdl_keys(:analysis_wdl).join('-') + "-#{SecureRandom.hex(4)}"
   end
 
   # helper to generate a URL to a workspace's GCP bucket
@@ -55,6 +56,11 @@ class UserWorkspace < ApplicationRecord
   end
 
   private
+
+  # check that the proposed name will allow for an analysis namespace that is available to the user
+  def check_analysis_namespace
+    analysis_namespace = self.name + '-analysis'
+  end
 
   # create a new benchmark workspace by cloning the reference workspace
   def create_benchmark_workspace

--- a/app/models/user_workspace.rb
+++ b/app/models/user_workspace.rb
@@ -42,7 +42,7 @@ class UserWorkspace < ApplicationRecord
 
   # generate a default name based off of reference analysis name on initialization
   def default_name
-    self.reference_analysis.extract_wdl_keys(:analysis_wdl).join('-') + "-#{SecureRandom.hex(4)}"
+    self.reference_analysis.extract_wdl_keys(:analysis_wdl).join('-') + "-#{ValidationTools.random_alphanumeric}"
   end
 
   # helper to generate a URL to a workspace's GCP bucket

--- a/app/views/user_workspaces/_form.html.erb
+++ b/app/views/user_workspaces/_form.html.erb
@@ -14,8 +14,8 @@
 
   <div class="form-group row">
     <div class="col-sm">
-      <%= form.label :name %>
-      <%= form.text_field :name, class: 'form-control' %>
+      <%= form.label :name %> <%= link_to "<i class='fas fa-edit'></i>".html_safe, "javascript:;", class: 'badge badge-light', id: 'edit-workspace-name' %>
+      <%= form.text_field :name, class: 'form-control', readonly: 'true' %>
     </div>
     <div class="col-sm">
       <%= form.label :project_id %>
@@ -39,6 +39,13 @@
     $('#save-user-workspace').on('click', function() {
         $('#generic-modal-title').html('Provisioning Workspace... Please Wait');
         launchModalSpinner('#generic-modal-spinner', '#generic-modal', function() { return true;})
+    });
+
+    $('#edit-workspace-name').on('click', function() {
+        $(this).toggleClass('badge-light badge-dark');
+        $(this).blur();
+        var readOnly = $('#user_workspace_name').prop('readonly')
+        $('#user_workspace_name').prop('readonly', !readOnly);
     });
 
 </script>

--- a/app/views/user_workspaces/benchmark_analyses/_benchmark_analyses.html.erb
+++ b/app/views/user_workspaces/benchmark_analyses/_benchmark_analyses.html.erb
@@ -13,9 +13,7 @@
         <td><%= benchmark_analysis.name %>/<%= benchmark_analysis.snapshot %></td>
         <td><%= benchmark_analysis.user_analysis.name %>/<%= benchmark_analysis.user_analysis.snapshot %></td>
         <td>
-          <%= link_to 'Run Benchmark', submit_benchmark_analysis_path(project: @user_workspace.namespace, name: @user_workspace.name,
-                                                                      user_analysis_id: @user_analysis.id, benchmark_analysis_id: benchmark_analysis.id),
-                      method: :post, class: 'btn btn-sm btn-outline-primary benchmark-analysis-btn', id: "submit-benchmark-analysis-#{benchmark_analysis.name_as_id}" %>
+          <%= render partial: 'user_workspaces/benchmark_analyses/submit_benchmark', locals: {benchmark_analysis: benchmark_analysis} %>
         </td>
       </tr>
     <% end %>

--- a/app/views/user_workspaces/benchmark_analyses/_submit_benchmark.html.erb
+++ b/app/views/user_workspaces/benchmark_analyses/_submit_benchmark.html.erb
@@ -1,0 +1,11 @@
+<%= form_tag(submit_benchmark_analysis_path(project: @user_workspace.namespace, name: @user_workspace.name,
+                                            user_analysis_id: @user_analysis.id, benchmark_analysis_id: benchmark_analysis.id),
+             class: 'form-inline') do %>
+  <div class="row">
+    <div class="col-sm">
+      <%= submit_tag 'Run Benchmark', class: 'btn btn-sm btn-outline-primary benchmark-analysis-btn', id: "submit-benchmark-analysis-#{benchmark_analysis.name_as_id}" %>
+      <%= select_tag :call_cache, options_for_select([['Caching: On', 1],['Caching: Off', 0]]), class: 'custom-select' %>&nbsp;
+      <i class="fas fa-question-circle" data-toggle="tooltip" title="Enable/Disable call caching for this submission.  Call caching will reuse outputs from previous matching submissions if available."></i>
+    </div>
+  </div>
+<% end %>

--- a/lib/fire_cloud_client.rb
+++ b/lib/fire_cloud_client.rb
@@ -938,15 +938,16 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   #   - +config_name+ (String) => name of requested configuration
   #   - +entity_type+ (String) => type of workspace entity (e.g. sample, participant, etc), optional
   #   - +entity_name+ (String) => name of workspace entity, optional
+  #   - +call_cache+ (Boolean) => enable Call Caching, defaults to true
   #
   # * *return*
   #   - +Hash+ of workflow submission details
-  def create_workspace_submission(workspace_namespace, workspace_name, config_namespace, config_name, entity_type=nil, entity_name=nil)
+  def create_workspace_submission(workspace_namespace, workspace_name, config_namespace, config_name, entity_type=nil, entity_name=nil, call_cache=true)
     path = self.api_root + "/api/workspaces/#{workspace_namespace}/#{workspace_name}/submissions"
     submission = {
         methodConfigurationNamespace: config_namespace,
         methodConfigurationName: config_name,
-        useCallCache: true,
+        useCallCache: call_cache,
         workflowFailureMode: 'NoNewCalls'
     }
     if entity_name.present? && entity_type.present?

--- a/lib/fire_cloud_client.rb
+++ b/lib/fire_cloud_client.rb
@@ -741,8 +741,8 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   #
   # * *return*
   #   - +Array+ of users & permission levels
-  def get_method_namespace_permissions(config_namespace)
-    path = self.api_root + "/api/methods/#{config_namespace}/permissions"
+  def get_method_namespace_permissions(method_namespace)
+    path = self.api_root + "/api/methods/#{method_namespace}/permissions"
     process_firecloud_request(:get, path)
   end
 

--- a/lib/validation_tools.rb
+++ b/lib/validation_tools.rb
@@ -14,4 +14,9 @@ module ValidationTools
   ALPHANUMERIC_SPACE_MESSAGE = 'contains invalid characters. Please use only alphanumeric or whitespace'
   FILENAME_CHARS_MESSAGE = 'contains invalid characters. Please use only alphanumeric, spaces, or the following: - _ . / ( )'
   OBJECT_LABELS_MESSAGE = 'contains invalid characters. Please use only alphanumeric, spaces, or the following: - _ . / ( ) + , :'
+
+  # generate a random n-character alphanumeric string
+  def self.random_alphanumeric(length=8)
+    [*('a'..'z'),*('0'..'9')].shuffle[0,length].join
+  end
 end


### PR DESCRIPTION
- Adding unique 8-character alphanumeric string to all default user workspace names to prevent namespace collisions for uploaded analyses.
- Adding call caching parameter to submissions to allow user to enable/disable for each submission