### PR TITLE
adding user roles to admin config, curator access, API retry & test fixes

### DIFF
--- a/app/controllers/admin_configurations_controller.rb
+++ b/app/controllers/admin_configurations_controller.rb
@@ -7,6 +7,7 @@ class AdminConfigurationsController < ApplicationController
   # GET /admin_configurations.json
   def index
     @admin_configurations = AdminConfiguration.where.not(config_type: AdminConfiguration::FIRECLOUD_ACCESS_NAME)
+    @users = User.all
   end
 
   # GET /admin_configurations/1
@@ -105,6 +106,24 @@ class AdminConfigurationsController < ApplicationController
     end
   end
 
+  # edit user roles
+  def edit_user
+    @user = User.find(params[:id])
+  end
+
+  # update a user account
+  def update_user
+    @user = User.find(params[:id])
+    respond_to do |format|
+      if @user.update(user_params)
+        format.html { redirect_to admin_configurations_path, notice: "User: '#{@user.email}' was successfully updated." }
+      else
+        format.html { render :edit_user }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_admin_configuration
@@ -121,5 +140,9 @@ class AdminConfigurationsController < ApplicationController
       params.require(:fire_cloud_profile).permit(:contactEmail, :email, :firstName, :lastName, :institute, :institutionalProgram,
                                               :nonProfitStatus, :pi, :programLocationCity, :programLocationState,
                                               :programLocationCountry, :title)
+    end
+
+    def user_params
+      params.require(:user).permit(:id, :admin, :curator)
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # auth action for portal admins
+  def authenticate_curator
+    unless current_user.acts_as_curator?
+      redirect_to site_path, alert: 'You do not have permission to access that page.' and return
+    end
+  end
+
   # overriding default new_session_path since we aren't using database_authenticatable
   def new_session_path(scope)
     new_user_session_path

--- a/app/controllers/reference_analyses_controller.rb
+++ b/app/controllers/reference_analyses_controller.rb
@@ -1,6 +1,6 @@
 class ReferenceAnalysesController < ApplicationController
   before_action :authenticate_user!
-  before_action :authenticate_admin
+  before_action :authenticate_curator
   before_action :set_reference_analysis, only: [:show, :edit, :update, :destroy, :reset_wdl_params]
   before_action :check_firecloud_availability, except: [:index, :show]
 

--- a/app/controllers/user_workspaces_controller.rb
+++ b/app/controllers/user_workspaces_controller.rb
@@ -302,10 +302,10 @@ class UserWorkspacesController < ApplicationController
       user_client.set_workspace_attributes(@user_workspace.namespace, @user_workspace.name, ws_attributes)
       logger.info "Starting submission #{params[:submission_id]} deletion in #{@user_workspace.name}"
       # use GCS Admin client to get/delete files
-      submission_files = ApplicationController.gcs_client.execute_gcloud_method(:get_workspace_files, @user_workspace.namespace,
+      submission_files = ApplicationController.gcs_client.execute_gcloud_method(:get_workspace_files, 0, @user_workspace.namespace,
                                                            @user_workspace.name, prefix: params[:submission_id])
       submission_files.each do |file|
-        ApplicationController.gcs_client.execute_gcloud_method(:delete_workspace_file, @user_workspace.namespace,
+        ApplicationController.gcs_client.execute_gcloud_method(:delete_workspace_file, 0, @user_workspace.namespace,
                                           @user_workspace.name, file.name)
       end
       render '/user_workspaces/submissions/delete_submission_files'
@@ -322,10 +322,10 @@ class UserWorkspacesController < ApplicationController
       head 503 and return
     end
 
-    requested_file = ApplicationController.gcs_client.execute_gcloud_method(:get_workspace_file, @user_workspace.namespace,
+    requested_file = ApplicationController.gcs_client.execute_gcloud_method(:get_workspace_file, 0, @user_workspace.namespace,
                                                        @user_workspace.name, params[:filename])
     if requested_file.present?
-      @signed_url = ApplicationController.gcs_client.execute_gcloud_method(:generate_signed_url, @user_workspace.namespace,
+      @signed_url = ApplicationController.gcs_client.execute_gcloud_method(:generate_signed_url, 0, @user_workspace.namespace,
                                                       @user_workspace.name, params[:filename], expires: 15)
       redirect_to @signed_url
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   attribute :access_token, :hstore
-  attribute :admin, :boolean
+  attribute :admin, :boolean, default: false
+  attribute :curator, :boolean, default: false
   attribute :full_name, :string
   attribute :registered_for_firecloud, :boolean, default: false
   attribute :added_to_unity_group, :boolean, default: false
@@ -88,5 +89,10 @@ class User < ApplicationRecord
       self.update(added_to_unity_group: true)
       Rails.logger.info "User group registration complete"
     end
+  end
+
+  # determine if user has curator permissions (is either curator or admin)
+  def acts_as_curator?
+    self.admin || self.curator
   end
 end

--- a/app/views/admin_configurations/edit_user.html.erb
+++ b/app/views/admin_configurations/edit_user.html.erb
@@ -1,0 +1,41 @@
+<h1>Editing <em><%= @user.email %></em> roles</h1>
+
+<%= form_for(@user, url: update_user_path(@user.id), html: {class: 'form'}) do |f| %>
+  <% if @user.errors.any? %>
+    <div class="bs-callout bs-callout-danger">
+      <h4><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h4>
+
+      <ul>
+        <% @user.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= f.hidden_field :id, value: @user.id %>
+  <div class="form-group row">
+    <div class="col-md-6">
+      <%= f.label :email %><br/>
+      <%= f.text_field :email, class: 'form-control', disabled: true %>
+    </div>
+    <div class="col-md-3">
+      <%= f.label :admin, "Admin Access <i class='fas fa-question-circle'></i>".html_safe, title: 'Grant administrative access.  Admins have access to all site functionality and can view all benchmarks.', data: {toggle: 'tooltip'} %><br/>
+      <%= f.select :admin, options_for_select([['Yes',1],['No',0]], @user.admin ? 1 : 0), {}, class: 'form-control' %>
+    </div>
+    <div class="col-md-3">
+      <%= f.label :curator, "Curator Access <i class='fas fa-question-circle'></i>".html_safe, title: "Grant access curator access (can manage reference analyses).  Curators do not have access to view user's benchmarks, or other admin functionality.", data: {toggle: 'tooltip'} %><br/>
+      <%= f.select :curator, options_for_select([['Yes',1],['No',0]], @user.curator ? 1 : 0), {}, class: 'form-control' %>
+    </div>
+  </div>
+  <div class="form-group row">
+    <div class="col-md-12">
+      <%= f.submit 'Update User', class: 'btn btn-lg btn-success', id: 'save-user' %>
+    </div>
+  </div>
+
+<% end %>
+<div class="row">
+  <div class="col-md-12">
+    <%= link_to "<span class='fas fa-chevron-left'></span> Back".html_safe, admin_configurations_path, class: 'btn btn-warning' %>
+  </div>
+</div>

--- a/app/views/admin_configurations/index.html.erb
+++ b/app/views/admin_configurations/index.html.erb
@@ -1,46 +1,95 @@
 <h1>Admin Control Panel</h1>
+<div id="tab-root">
+  <ul class="nav nav-tabs" role="tablist" id="admin-tabs">
+    <li role="presentation" class="nav-item" id="admin-config-nav"><a href="#admin-config-panel" class="nav-link active" data-toggle="tab">Configuration Options<i class="fas fa-fw fa-cog"></i></a></li>
+    <li role="presentation" class="nav-item" id="users-nav"><a href="#users-panel" class="nav-link" data-toggle="tab">User Roles<i class="fas fa-fw fa-user"></i></a></li>
+  </ul>
+  <div class="tab-content top-pad-small">
+    <div class="tab-pane active" id="admin-config-panel">
+      <div class="row">
+        <div class="col-md">
+          <div class="table-responsive">
+            <table class="table table-striped table-active" id="admin-config">
+              <thead>
+              <tr>
+                <th>Config Type</th>
+                <th>Value</th>
+                <th>Options</th>
+                <th>Actions</th>
+              </tr>
+              </thead>
 
-<div class="row">
-  <div class="col-md">
-    <div class="table-responsive">
-      <table class="table table-striped table-active" id="admin-config">
-        <thead>
-        <tr>
-          <th>Config Type</th>
-          <th>Value</th>
-          <th>Options</th>
-          <th>Actions</th>
-        </tr>
-        </thead>
-
-        <tbody>
-        <% @admin_configurations.each do |admin_configuration| %>
-          <tr>
-            <td><%= admin_configuration.config_type %></td>
-            <td><%= admin_configuration.convert_value_by_type %></td>
-            <td>
-              <% admin_configuration.options.each do |name, val| %>
-                <span class="badge badge-dark"><%= name %></span>&nbsp;<span class="badge badge-secondary"><%= val %></span><br />
+              <tbody>
+              <% @admin_configurations.each do |admin_configuration| %>
+                <tr>
+                  <td><%= admin_configuration.config_type %></td>
+                  <td><%= admin_configuration.convert_value_by_type %></td>
+                  <td>
+                    <% admin_configuration.options.each do |name, val| %>
+                      <span class="badge badge-dark"><%= name %></span>&nbsp;<span class="badge badge-secondary"><%= val %></span><br />
+                    <% end %>
+                  </td>
+                  <td class="actions">
+                    <%= link_to 'Edit', edit_admin_configuration_path(admin_configuration), class: 'btn btn-sm btn-primary' %>&nbsp;
+                    <%= link_to 'Destroy', admin_configuration, method: :delete, data: { confirm: 'Are you sure you want to delete this configuration?' }, class: 'btn btn-sm btn-danger' %>
+                  </td>
+                </tr>
               <% end %>
-            </td>
-            <td class="actions">
-              <%= link_to 'Edit', edit_admin_configuration_path(admin_configuration), class: 'btn btn-sm btn-primary' %>&nbsp;
-              <%= link_to 'Destroy', admin_configuration, method: :delete, data: { confirm: 'Are you sure you want to delete this configuration?' }, class: 'btn btn-sm btn-danger' %>
-            </td>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
+              </tbody>
+            </table>
 
-      <p><%= link_to 'New Admin Configuration', new_admin_configuration_path, class: 'btn btn-lg btn-success' %></p>
+            <p><%= link_to 'New Admin Configuration', new_admin_configuration_path, class: 'btn btn-lg btn-success' %></p>
 
-      <script type="text/javascript">
+            <script type="text/javascript">
 
-          $('#admin-config').DataTable({
-              pagingType: 'full_numbers'
-          });
+                $('#admin-config').DataTable({
+                    pagingType: 'full_numbers'
+                });
 
-      </script>
+            </script>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="tab-pane" id="users-panel">
+      <div class="row">
+        <div class="col-md">
+          <div class="table-responsive">
+            <table class="table table-striped table-active" id="user-table">
+              <thead>
+              <tr>
+                <th>Email</th>
+                <th>Special Roles</th>
+                <th>Edit</th>
+              </tr>
+              </thead>
+              <tbody>
+              <% @users.each do |user| %>
+                <tr>
+                  <td><%= user.email %></td>
+                  <td>
+                    <%= user.admin ? "<span class='badge badge-danger'><i class='fas fa-lock'></i> Admin</span>".html_safe : nil %>
+                    <%= user.curator ? "<span class='badge badge-warning'><i class='fas fa-flask'></i> Curator</span>".html_safe : nil %>
+                  </td>
+                  <td class="actions">
+                    <%= link_to "<span class='fas fa-edit'></span> Edit".html_safe, edit_user_path(user), class: "btn btn-sm btn-primary" %>
+                  </td>
+                </tr>
+              <% end %>
+              </tbody>
+            </table>
+          </div>
+          <script type="text/javascript">
+              $('#user-table').dataTable({
+                  pagingType: "full_numbers",
+                  order: [[0, 'asc']],
+                  language: {
+                      search: "Filter Results By: "
+                  }
+              });
+          </script>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -27,9 +27,11 @@
             <div class="dropdown-menu dropdown-menu-right">
             <% if current_user.admin? %>
               <%= link_to "<i class='fas fa-fw fa-lock'></i> Admin Control Panel".html_safe, admin_configurations_path, class: 'dropdown-item', id: 'admin-panel-nav' %>
-              <%= link_to "<i class='fas fa-fw fa-flask'></i> Reference Analyses".html_safe, reference_analyses_path, class: 'dropdown-item', id: 'reference-analyses-nav' %>
-              <div class="dropdown-divider"></div>
             <% end %>
+            <% if current_user.acts_as_curator? %>
+              <%= link_to "<i class='fas fa-fw fa-flask'></i> Reference Analyses".html_safe, reference_analyses_path, class: 'dropdown-item', id: 'reference-analyses-nav' %>
+            <% end %>
+              <div class="dropdown-divider"></div>
               <%= link_to "<i class='fas fa-fw fa-user'></i> My Profile".html_safe, profile_path, class: 'dropdown-item', id: 'firecloud-profile-nav' %>
               <%= link_to "<i class='fas fa-fw fa-folder'></i> My Billing Projects".html_safe, projects_path, class: 'dropdown-item', id: 'billing-projects-nav' %>
               <%= link_to "<i class='fas fa-fw fa-project-diagram'></i> My Benchmarks".html_safe, user_workspaces_path, class: 'dropdown-item', id: 'user-workspaces-nav' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   resources :admin_configurations, path: 'admin'
   get 'admin/service_account/profile', to: 'admin_configurations#get_service_account_profile', as: :get_service_account_profile
   post 'admin/service_account/profile', to: 'admin_configurations#update_service_account_profile', as: :update_service_account_profile
+  get 'admin/users/:id/edit', to: 'admin_configurations#edit_user', as: :edit_user
+  match 'admin/users/:id', to: 'admin_configurations#update_user', via: [:post, :patch], as: :update_user
+
   resources :reference_analyses do
     member do
       put 'reset_wdl_params', to: 'reference_analyses#reset_wdl_params', as: :reset_wdl_params

--- a/db/migrate/20181211185822_add_curator_to_users.rb
+++ b/db/migrate/20181211185822_add_curator_to_users.rb
@@ -1,0 +1,5 @@
+class AddCuratorToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :curator, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_24_220457) do
+ActiveRecord::Schema.define(version: 2018_12_11_185822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(version: 2018_08_24_220457) do
     t.boolean "admin", default: false
     t.boolean "registered_for_firecloud", default: false
     t.boolean "added_to_unity_group", default: false
+    t.boolean "curator", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,11 +5,14 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-@reference_analysis = ReferenceAnalysis.create(firecloud_project: 'unity-benchmarking-development',
+AdminConfiguration.create(config_type: 'Unity FireCloud User Group', value_type: 'string', value: 'unity-benchmark-users')
+@reference_analysis = ReferenceAnalysis.create(firecloud_project: 'unity-benchmark-test',
                                                firecloud_workspace: 'test-workspace',
-                                               analysis_wdl: 'unity-benchmark-development/test-analysis/5',
-                                               benchmark_wdl: 'unity-benchmark-development/test-benchmark/3',
-                                               orchestration_wdl: 'unity-benchmark-development/test-orchestration/2')
+                                               analysis_wdl: 'unity-benchmark-test/test-analysis/1',
+                                               benchmark_wdl: 'unity-benchmark-test/test-benchmark/1',
+                                               orchestration_wdl: 'unity-benchmark-test/test-orchestration/1')
 @reference_analysis.load_parameters_from_wdl!
 @user = User.create(provider: 'google_oauth2', uid: 123545, email: 'unity-admin@broadinstitute.org',
                     registered_for_firecloud: true, admin: true)
+@user2 = User.create(provider: 'google_oauth2', uid: 132515, email: 'unity-curator@broadinstitute.org',
+                    registered_for_firecloud: true, curator: true)

--- a/lib/fire_cloud_client.rb
+++ b/lib/fire_cloud_client.rb
@@ -19,7 +19,11 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   # default auth scopes
   GOOGLE_SCOPES = %w(https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-billing.readonly https://www.googleapis.com/auth/cloud-platform.read-only)
   # constant used for retry loops in process_firecloud_request and execute_gcloud_method
-  MAX_RETRY_COUNT = 3
+  MAX_RETRY_COUNT = 5
+  # constant used for incremental backoffs on retries (in seconds); ignored when running unit/integration test suite
+  RETRY_INTERVAL = Rails.env == 'test' ? 0 : 15
+  # List of URLs/Method names to ignore incremental backoffs on (in cases of UI blocking)
+  RETRY_IGNORE_LIST = ["#{BASE_URL}/register", :generate_signed_url, :generate_api_url]
   # location of Google service account JSON (must be absolute path to file)
   SERVICE_ACCOUNT_KEY = !ENV['SERVICE_ACCOUNT_KEY'].blank? ? File.absolute_path(ENV['SERVICE_ACCOUNT_KEY']) : ''
   # Permission values allowed for FireCloud workspace ACLs
@@ -214,59 +218,62 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   #   - +http_method+ (String, Symbol) => valid http method
   #   - +path+ (String) => FireCloud REST API path
   #   - +payload+ (Hash) => HTTP POST/PATCH/PUT body for creates/updates, defaults to nil
-  #   - +opts+ (Hash) => Hash of extra options (defaults are file_upload=false, max_attemps=MAX_RETRY_COUNT)
+  #		- +opts+ (Hash) => Hash of extra options (defaults are file_upload=false, max_attemps=MAX_RETRY_COUNT)
+  #   - +retry_count+ (Integer) => current count of number of retries.  defaults to 0 and self-increments
   #
   # * *return*
   #   - +Hash+, +Boolean+ depending on response body
   # * *raises*
   #   - +RuntimeError+
-  def process_firecloud_request(http_method, path, payload=nil, opts={})
+  def process_firecloud_request(http_method, path, payload=nil, opts={}, retry_count=0)
     # set up default options
-    request_opts = {file_upload: false, max_attempts: MAX_RETRY_COUNT}.merge(opts)
+    request_opts = {file_upload: false}.merge(opts)
 
-    # set default headers of valid access token
+    # check for token expiry first before executing
+    if self.access_token_expired?
+      Rails.logger.info "FireCloudClient token expired, refreshing access token"
+      self.refresh_access_token
+    end
+    # set default headers
     headers = {
-        'Authorization' => "Bearer #{self.valid_access_token['access_token']}"
+        'Authorization' => "Bearer #{self.access_token['access_token']}"
     }
     # if not uploading a file, set the content_type to application/json
     if !request_opts[:file_upload]
       headers.merge!({'Content-Type' => 'application/json'})
     end
 
-    # initialize counter to prevent endless feedback loop
-    @retry_count ||= 0
-
     # process request
-    if @retry_count < request_opts[:max_attempts]
+    if retry_count < MAX_RETRY_COUNT
       begin
-        @retry_count += 1
         @obj = RestClient::Request.execute(method: http_method, url: path, payload: payload, headers: headers)
         # handle response codes as necessary
         if ok?(@obj.code) && !@obj.body.blank?
-          @retry_count = 0
           begin
             return JSON.parse(@obj.body)
           rescue JSON::ParserError => e
             return @obj.body
           end
         elsif ok?(@obj.code) && @obj.body.blank?
-          @retry_count = 0
           return true
         else
           Rails.logger.info "Unexpected response #{@obj.code}, not sure what to do here..."
           @obj.message
         end
       rescue RestClient::Exception => e
-        context = " encountered when requesting '#{path}'"
-        log_message = "#{Time.now}: " + e.message + context
+        context = " encountered when requesting '#{path}', attempt ##{retry_count + 1}"
+        log_message = e.message + context
         Rails.logger.error log_message
         @error = e
-        process_firecloud_request(http_method, path, payload, opts)
+        unless RETRY_IGNORE_LIST.include?(path)
+          retry_time = retry_count * RETRY_INTERVAL
+          sleep(retry_time)
+        end
+        process_firecloud_request(http_method, path, payload, opts, retry_count + 1)
       end
     else
-      @retry_count = 0
       error_message = parse_error_message(@error)
-      Rails.logger.error "Retry count exceeded - #{error_message}"
+      Rails.logger.error "Retry count exceeded when requesting '#{path}' - #{error_message}"
       raise RuntimeError.new(error_message)
     end
   end
@@ -1456,25 +1463,28 @@ class FireCloudClient < Struct.new(:user, :project, :access_token, :api_root, :s
   #
   # * *params*
   #   - +method_name+ (String, Symbol) => name of FireCloudClient GCS method to execute
+  #   - +retry_count+ (Integer) => current count of number of retries.  defaults to 0 and self-increments
   #   - +params+ (Array) => array of method parameters (passed with splat operator, so does not need to be an actual array)
   #
   # * *return*
   #   - Object depends on method, can be one of the following: +Google::Cloud::Storage::Bucket+, +Google::Cloud::Storage::File+,
   #     +Google::Cloud::Storage::FileList+, +Boolean+, +File+, or +String+
 
-  def execute_gcloud_method(method_name, *params)
-    @retries ||= 0
-    if @retries < MAX_RETRY_COUNT
+  def execute_gcloud_method(method_name, retry_count=0, *params)
+    if retry_count < MAX_RETRY_COUNT
       begin
         self.send(method_name, *params)
       rescue => e
         @error = e.message
-        Rails.logger.info "Error calling #{method_name} with #{params.join(', ')}; #{e.message} -- retry ##{@retries}"
-        @retries += 1
-        execute_gcloud_method(method_name, *params)
+        Rails.logger.info "error calling #{method_name} with #{params.join(', ')}; #{e.message} -- attempt ##{retry_count + 1}"
+        unless RETRY_IGNORE_LIST.include?(method_name)
+          retry_time = retry_count * RETRY_INTERVAL
+          sleep(retry_time)
+        end
+        execute_gcloud_method(method_name, retry_count + 1, *params)
       end
     else
-      Rails.logger.info "Retry count exceeded: #{@error}"
+      Rails.logger.info "Retry count exceeded calling #{method_name} with #{params.join(', ')}: #{@error}"
       raise RuntimeError.new "#{@error}"
     end
   end

--- a/test/controllers/admin_configurations_controller_test.rb
+++ b/test/controllers/admin_configurations_controller_test.rb
@@ -69,4 +69,11 @@ class AdminConfigurationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_configurations_url
     puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
   end
+
+  test "should manage curator role" do
+    puts "#{File.basename(__FILE__)}: #{self.method_name}"
+    curator = User.find_by(curator: true)
+    get edit_user_path(curator.id)
+    puts "#{File.basename(__FILE__)}: #{self.method_name} successful!"
+  end
 end


### PR DESCRIPTION
* Adding curator role to user accounts (can manage reference_analyses, but not admin configurations)
* Adding user role management to admin panel
* Refactoring fire_cloud_client#process_firecloud_request & fire_cloud_client#execute_gcloud_method to correctly handle retries in the event of failures
* Fixed test seeds to account for new reference_analysis validations